### PR TITLE
Declare properties

### DIFF
--- a/includes/ProductsApi.php
+++ b/includes/ProductsApi.php
@@ -32,6 +32,20 @@ class ProductsApi {
 	private $hiive;
 
 	/**
+	 * Namespace for the REST API.
+	 *
+	 * @var string
+	 */
+	private $namespace;
+
+	/**
+	 * REST base for the products endpoint.
+	 *
+	 * @var string
+	 */
+	private $rest_base;
+
+	/**
 	 * ProductsApi constructor.
 	 *
 	 * @param HiiveConnection $hiive           Instance of the HiiveConnection class.

--- a/includes/ProductsApi.php
+++ b/includes/ProductsApi.php
@@ -118,7 +118,6 @@ class ProductsApi {
 
 				$this->setTransient( $products );
 			}
-
 		}
 
 		return new WP_REST_Response( $products, 200 );


### PR DESCRIPTION
Fixes the issue where, when WP_DEBUG is enabled, the deprecation notice was outputting alongside the JSON for the site connect request, causing the connection to fail.